### PR TITLE
Typo in BrushReset

### DIFF
--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -318,7 +318,7 @@ d3.parcoords = function(config) {
   // TODO
   pc.brushReset = function(dimension) {
     yscale[dimension].brush.clear()(
-      pc1.g()
+      pc.g()
         .filter(function(p) {
           return dimension == p;
         })


### PR DESCRIPTION
`pc1.g()` should be `pc.g()`

The function appears to work for my purposes after this adjustment.
