### PR TITLE
Improved renderQueue performance

### DIFF
--- a/src/renderQueue.js
+++ b/src/renderQueue.js
@@ -17,15 +17,14 @@ d3.renderQueue = (function(func) {
     rq.invalidate = function() { valid = false; };
 
     function doFrame() {
-      if (!valid) return false;
-      if (_i > _queue.length) return false;
+      if (!valid) return true;
+      if (_i > _queue.length) return true;
       var chunk = _queue.slice(_i,_i+_rate);
       _i += _rate;
       chunk.map(func);
-      d3.timer(doFrame);
     }
 
-    doFrame();
+    d3.timer(doFrame);
   };
 
   rq.data = function(data) {


### PR DESCRIPTION
doFrame() needs to return true to stop the [d3.timer](https://github.com/mbostock/d3/wiki/Transitions#wiki-d3_timer). Also, a new timer was created on each call to doFrame(), which slows down the animation as it processes the queue.
