### PR TITLE
Making parcoords non-selectable via CSS

### DIFF
--- a/d3.parcoords.css
+++ b/d3.parcoords.css
@@ -32,3 +32,11 @@
 .parcoords canvas.faded {
   opacity: 0.25;
 }
+.parcoords {
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}


### PR DESCRIPTION
This prevents the user from highlighting text while exploring the data.  Should cover most vendor specific prefixes.
