### PR TITLE
FIX: Keep axes brushable and reorderable on updates

### DIFF
--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -541,6 +541,8 @@ pc.updateAxes = function() {
   	.each(function(d) { d3.select(this).call(axis.scale(yscale[d])); });
 
   if (flags.shadows) paths(__.data, ctx.shadows);
+  if (flags.brushable) pc.brushable();
+  if (flags.reorderable) pc.reorderable();
   return this;
 };
 

--- a/src/axis.js
+++ b/src/axis.js
@@ -68,6 +68,8 @@ pc.updateAxes = function() {
   	.each(function(d) { d3.select(this).call(axis.scale(yscale[d])); });
 
   if (flags.shadows) paths(__.data, ctx.shadows);
+  if (flags.brushable) pc.brushable();
+  if (flags.reorderable) pc.reorderable();
   return this;
 };
 


### PR DESCRIPTION
When I configure my parcoords to be reorderable, and I call updateAxes() at
some point, the axes wouldn't be reorderable afterwards.

Same for brushable.
