### PR TITLE
Add a function to retrieve current brush extents.

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -95,6 +95,24 @@ pc.brushable = function() {
   return this;
 };
 
+pc.brushExtents = function() {
+  var extents = {};
+  __.dimensions.forEach(function(d) {
+    var brush = yscale[d].brush;
+    if (!brush.empty()) {
+      // https://github.com/mbostock/d3/wiki/SVG-Controls#brush_extent
+      // NOTE: According to the documentation, inversion is required *if* the
+      //       brush is moved by the user (on mousemove following a mousedown).
+      //       However, this gets me the wrong values, so no inversion here.
+      //       See issue: mbostock/d3 #1981
+      var extent = brush.extent();
+      extent.sort(d3.ascending);
+      extents[d] = extent;
+    }
+  });
+  return extents;
+};
+
 // Jason Davies, http://bl.ocks.org/1341281
 pc.reorderable = function() {
   if (!g) pc.createAxes();


### PR DESCRIPTION
I need this for an application I'm working on. However, this can also serve as a
starting point for fixing the brush resets on resize. I'll have a look at that
soon.

**NOTE**: I'll rebase this commit master before the merge and create a new pull request. I'm working on multiple fixes/features at the same time.
