### PR TITLE
throw Error objects instead of strings

### DIFF
--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -1067,7 +1067,7 @@ function brushPredicate(predicate) {
 
   predicate = String(predicate).toUpperCase();
   if (predicate !== "AND" && predicate !== "OR") {
-    throw "Invalid predicate " + predicate;
+    throw new Error("Invalid predicate " + predicate);
   }
 
   brush.predicate = predicate;
@@ -1086,7 +1086,7 @@ pc.brushMode = function(mode) {
   }
 
   if (pc.brushModes().indexOf(mode) === -1) {
-    throw "pc.brushmode: Unsupported brush mode: " + mode;
+    throw new Error("pc.brushmode: Unsupported brush mode: " + mode);
   }
 
   // Make sure that we don't trigger unnecessary events by checking if the mode
@@ -1168,7 +1168,7 @@ pc.brushMode = function(mode) {
             return within[__.dimensions[p].type](d,p,dimension);
           });
         default:
-          throw "Unknown brush predicate " + __.brushPredicate;
+          throw new Error("Unknown brush predicate " + __.brushPredicate);
         }
       });
   };
@@ -1508,7 +1508,7 @@ pc.brushMode = function(mode) {
       case "OR":
         return ids.some(function(id) { return crossesStrum(d, id); });
       default:
-        throw "Unknown brush predicate " + __.brushPredicate;
+        throw new Error("Unknown brush predicate " + __.brushPredicate);
       }
     });
   }
@@ -1710,7 +1710,7 @@ pc.brushMode = function(mode) {
             });
         });
       default:
-        throw "Unknown brush predicate " + __.brushPredicate;
+        throw new Error("Unknown brush predicate " + __.brushPredicate);
       }
     });
   };
@@ -2135,7 +2135,7 @@ pc.brushMode = function(mode) {
       case "OR":
         return ids.some(function(id) { return crossesStrum(d, id); });
       default:
-        throw "Unknown brush predicate " + __.brushPredicate;
+        throw new Error("Unknown brush predicate " + __.brushPredicate);
       }
     });
   }

--- a/src/brushes/1D.js
+++ b/src/brushes/1D.js
@@ -53,7 +53,7 @@
             return within[__.dimensions[p].type](d,p,dimension);
           });
         default:
-          throw "Unknown brush predicate " + __.brushPredicate;
+          throw new Error("Unknown brush predicate " + __.brushPredicate);
         }
       });
   };

--- a/src/brushes/1D.multi.js
+++ b/src/brushes/1D.multi.js
@@ -61,7 +61,7 @@
             });
         });
       default:
-        throw "Unknown brush predicate " + __.brushPredicate;
+        throw new Error("Unknown brush predicate " + __.brushPredicate);
       }
     });
   };

--- a/src/brushes/2D.strums.js
+++ b/src/brushes/2D.strums.js
@@ -185,7 +185,7 @@
       case "OR":
         return ids.some(function(id) { return crossesStrum(d, id); });
       default:
-        throw "Unknown brush predicate " + __.brushPredicate;
+        throw new Error("Unknown brush predicate " + __.brushPredicate);
       }
     });
   }

--- a/src/brushes/angular.js
+++ b/src/brushes/angular.js
@@ -258,7 +258,7 @@
       case "OR":
         return ids.some(function(id) { return crossesStrum(d, id); });
       default:
-        throw "Unknown brush predicate " + __.brushPredicate;
+        throw new Error("Unknown brush predicate " + __.brushPredicate);
       }
     });
   }

--- a/src/brushes/brushmode.js
+++ b/src/brushes/brushmode.js
@@ -31,7 +31,7 @@ function brushPredicate(predicate) {
 
   predicate = String(predicate).toUpperCase();
   if (predicate !== "AND" && predicate !== "OR") {
-    throw "Invalid predicate " + predicate;
+    throw new Error("Invalid predicate " + predicate);
   }
 
   brush.predicate = predicate;
@@ -50,7 +50,7 @@ pc.brushMode = function(mode) {
   }
 
   if (pc.brushModes().indexOf(mode) === -1) {
-    throw "pc.brushmode: Unsupported brush mode: " + mode;
+    throw new Error("pc.brushmode: Unsupported brush mode: " + mode);
   }
 
   // Make sure that we don't trigger unnecessary events by checking if the mode


### PR DESCRIPTION
There is no stack trace for debug if the thrown element is a string.
