### PR TITLE
fully remove g when `removeAxes`

### DIFF
--- a/src/axis.js
+++ b/src/axis.js
@@ -61,6 +61,7 @@ pc.createAxes = function() {
 
 pc.removeAxes = function() {
   g.remove();
+  g = undefined;
   return this;
 };
 


### PR DESCRIPTION
As I was testing #265 I found what I think to be a bug in `removeAxes`.  While `removeAxes` does `g.remove()`, `g` remains even though the elements have been removed from the DOM.  With `createAxes`, the first line `if (g) pc.removeAxes();` takes care of this problem.  However, `reorderable` does this `if (!g) pc.createAxes();`, so it still sees `g` even if we called `removeAxes()`.  I think we can resolve all problems by simply setting `g = undefined` after `g.remove` in `removeAxes()`.

Disclaimer:: my JavaScript is not real strong.  I actually am using this for a `htmlwidget` in `R`, so I apologize if I am missing something obvious.

Thanks for this fantastic work!