### PR TITLE
brushExtents Example fixes

### DIFF
--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -1195,7 +1195,7 @@ pc.brushMode = function(mode) {
 			delete pc.brushReset;
 		},
 		selected: selected,
-		//brushState: brushExtents
+		brushState: brushExtents
 	}
 })();
 // brush mode: 2D-strums

--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -1038,7 +1038,7 @@ pc.brushMode = function(mode) {
 			// loop over each dimension and update appropriately (if it was passed in through extents)
 			__.dimensions.forEach(function(d) {
 				if (extents[d] === undefined){
-					continue;
+					return; // continue
 				}
 
 				var brush = brushes[d];

--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -142,7 +142,7 @@ function getset(obj,state,events)  {
 };
 
 function extend(target, source) {
-  for (key in source) {
+  for (var key in source) {
     target[key] = source[key];
   }
   return target;
@@ -351,12 +351,7 @@ pc.renderBrushed = function() {
 };
 
 function isBrushed() {
-  if (__.brushed) {
-    return true;
-  }
-  return false;
-  // TODO: debug: whats going on here??
-  /*if (__.brushed && __.brushed.length !== __.data.length)
+  if (__.brushed && __.brushed.length !== __.data.length)
     return true;
 
   var object = brush.currentMode().brushState();
@@ -366,7 +361,7 @@ function isBrushed() {
       return true;
     }
   }
-  return false;*/
+  return false;
 };
 
 pc.render.default = function() {
@@ -959,248 +954,249 @@ pc.brushMode = function(mode) {
 // brush mode: 1D-Axes
 
 (function() {
-  var brushes = {};
+	var brushes = {};
 
-  function is_brushed(p) {
-    return !brushes[p].empty();
-  }
+	function is_brushed(p) {
+		return !brushes[p].empty();
+	}
 
-  // data within extents
-  function selected() {
-    var actives = __.dimensions.filter(is_brushed),
-        extents = actives.map(function(p) { return brushes[p].extent(); });
+	// data within extents
+	function selected() {
+		var actives = __.dimensions.filter(is_brushed),
+				extents = actives.map(function(p) { return brushes[p].extent(); });
 
-    // We don't want to return the full data set when there are no axes brushed.
-    // Actually, when there are no axes brushed, by definition, no items are
-    // selected. So, let's avoid the filtering and just return false.
-    //if (actives.length === 0) return false;
+		// We don't want to return the full data set when there are no axes brushed.
+		// Actually, when there are no axes brushed, by definition, no items are
+		// selected. So, let's avoid the filtering and just return false.
+		//if (actives.length === 0) return false;
 
-    // Resolves broken examples for now. They expect to get the full dataset back from empty brushes
-    if (actives.length === 0) return __.data;
+		// Resolves broken examples for now. They expect to get the full dataset back from empty brushes
+		if (actives.length === 0) return __.data;
 
-    // test if within range
-    var within = {
-      "date": function(d,p,dimension) {
+		// test if within range
+		var within = {
+			"date": function(d,p,dimension) {
 	if (typeof yscale[p].rangePoints === "function") { // if it is ordinal
-          return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
-        } else {
-          return extents[dimension][0] <= d[p] && d[p] <= extents[dimension][1]
-        }
-      },
-      "number": function(d,p,dimension) {
-        if (typeof yscale[p].rangePoints === "function") { // if it is ordinal
-          return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
-        } else {
-          return extents[dimension][0] <= d[p] && d[p] <= extents[dimension][1]
-        }
-      },
-      "string": function(d,p,dimension) {
-        return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
-      }
-    };
+					return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
+				} else {
+					return extents[dimension][0] <= d[p] && d[p] <= extents[dimension][1]
+				}
+			},
+			"number": function(d,p,dimension) {
+				if (typeof yscale[p].rangePoints === "function") { // if it is ordinal
+					return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
+				} else {
+					return extents[dimension][0] <= d[p] && d[p] <= extents[dimension][1]
+				}
+			},
+			"string": function(d,p,dimension) {
+				return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
+			}
+		};
 
-    return __.data
-      .filter(function(d) {
-        switch(brush.predicate) {
-        case "AND":
-          return actives.every(function(p, dimension) {
-            return within[__.types[p]](d,p,dimension);
-          });
-        case "OR":
-          return actives.some(function(p, dimension) {
-            return within[__.types[p]](d,p,dimension);
-          });
-        default:
-          throw "Unknown brush predicate " + __.brushPredicate;
-        }
-      });
-  };
+		return __.data
+			.filter(function(d) {
+				switch(brush.predicate) {
+				case "AND":
+					return actives.every(function(p, dimension) {
+						return within[__.types[p]](d,p,dimension);
+					});
+				case "OR":
+					return actives.some(function(p, dimension) {
+						return within[__.types[p]](d,p,dimension);
+					});
+				default:
+					throw "Unknown brush predicate " + __.brushPredicate;
+				}
+			});
+	};
 
-  function brushExtents(extents) {
-    if(typeof(extents) === 'undefined')
-    {
-      var extents = {};
-      __.dimensions.forEach(function(d) {
-        var brush = brushes[d];
-        if (brush !== undefined && !brush.empty()) {
-          var extent = brush.extent();
-          extent.sort(d3.ascending);
-          extents[d] = extent;
-        }
-      });
-    }
-    else
-    {
-      //first get all the brush selections
-      var brushSelections = {};
-      g.selectAll('.brush')
-        .each(function(d) {
-          brushSelections[d] = d3.select(this);
+	function brushExtents(extents) {
+		if(typeof(extents) === 'undefined')
+		{
+			var extents = {};
+			__.dimensions.forEach(function(d) {
+				var brush = brushes[d];
+				if (brush !== undefined && !brush.empty()) {
+					var extent = brush.extent();
+					extent.sort(d3.ascending);
+					extents[d] = extent;
+				}
+			});
+			return extents;
+		}
+		else
+		{
+			//first get all the brush selections
+			var brushSelections = {};
+			g.selectAll('.brush')
+				.each(function(d) {
+					brushSelections[d] = d3.select(this);
 
-      });
+			});
 
-      // loop over each dimension and update appropriately (if it was passed in through extents)
-      __.dimensions.forEach(function(d) {
-        if (extents[d] === undefined){
-          return pc;
-        }
+			// loop over each dimension and update appropriately (if it was passed in through extents)
+			__.dimensions.forEach(function(d) {
+				if (extents[d] === undefined){
+					continue;
+				}
 
-        var brush = brushes[d];
-        if (brush !== undefined) {
-          //update the extent
-          brush.extent(extents[d]);
+				var brush = brushes[d];
+				if (brush !== undefined) {
+					//update the extent
+					brush.extent(extents[d]);
 
-          //redraw the brush
-          brush(brushSelections[d]);
+					//redraw the brush
+					brush(brushSelections[d]);
 
-          //fire some events
-          brush.event(brushSelections[d]);
-        }
-      });
+					//fire some events
+					brush.event(brushSelections[d]);
+				}
+			});
 
-      //redraw the chart
-      pc.renderBrushed();
-    }
-    return pc;
-  }
+			//redraw the chart
+			pc.renderBrushed();
+		}
+		return pc;
+	}
 
-  /** A setter for 1D-axes brushes, accessible from outside of parcoords. */
-  function updateBrush(dimension, extent, duration) {
-    var brush = brushes[dimension];
-    // set brush extent
-    brush.extent(extent);
-    /*
-    // set brush extents for all dimensions
-    for (var key in initialExtents) {
-      brushes[key].extent(initialExtents[key])
-    }*/
-    if (g) {
-      //first get all the brush selections
-      var brushSelections = {};
-      g.selectAll('.brush')
-        .each(function(d) {
-          brushSelections[d] = d3.select(this);
-        });
+	/** A setter for 1D-axes brushes, accessible from outside of parcoords. */
+	function updateBrush(dimension, extent, duration) {
+		var brush = brushes[dimension];
+		// set brush extent
+		brush.extent(extent);
+		/*
+		// set brush extents for all dimensions
+		for (var key in initialExtents) {
+			brushes[key].extent(initialExtents[key])
+		}*/
+		if (g) {
+			//first get all the brush selections
+			var brushSelections = {};
+			g.selectAll('.brush')
+				.each(function(d) {
+					brushSelections[d] = d3.select(this);
+				});
 
-      //redraw the brush
-      brushSelections[dimension]
-        .transition()
-        .duration(duration)
-        .call(brush)
-      //brush(brushSelections[d]);
+			//redraw the brush
+			brushSelections[dimension]
+				.transition()
+				.duration(duration)
+				.call(brush)
+			//brush(brushSelections[d]);
 
-      //fire some events
-      brush.event(brushSelections[dimension]);
+			//fire some events
+			brush.event(brushSelections[dimension]);
 
-    }
+		}
 
 /*
-    // update all brush extents
-    if (g) {
-      g.selectAll('.brush').each(function(d) {
-  	    if (!(brushes[d].empty())){
-  		  d3.select(this) // draws the brush initially
-  		    .call(brushes[d]);
+		// update all brush extents
+		if (g) {
+			g.selectAll('.brush').each(function(d) {
+				if (!(brushes[d].empty())){
+				d3.select(this) // draws the brush initially
+					.call(brushes[d]);
 
-  		  d3.select(this) // re-draw brushes with set extent, then start brush event
-  		    .transition()
-  		    .duration(duration)
-  		    .call(brushes[d].extent(initialExtents[d]))
-  		    .call(brushes[d].event);
+				d3.select(this) // re-draw brushes with set extent, then start brush event
+					.transition()
+					.duration(duration)
+					.call(brushes[d].extent(initialExtents[d]))
+					.call(brushes[d].event);
 
-  	    } else {
-  		    d3.select(this).call(brushes[d].clear());
-  	    }
-      });
-    }*/
+				} else {
+					d3.select(this).call(brushes[d].clear());
+				}
+			});
+		}*/
 
-    return pc;
-  };
+		return pc;
+	};
 
-  function brushFor(axis) {
-    var brush = d3.svg.brush();
+	function brushFor(axis) {
+		var brush = d3.svg.brush();
 
-    brush
-      .y(yscale[axis])
-      .on("brushstart", function() {
+		brush
+			.y(yscale[axis])
+			.on("brushstart", function() {
 				if(d3.event.sourceEvent !== null) {
 					d3.event.sourceEvent.stopPropagation();
 				}
 			})
-      .on("brush", function() {
-        brushUpdated(selected());
-      })
-      .on("brushend", function() {
-        events.brushend.call(pc, __.brushed);
-      });
+			.on("brush", function() {
+				brushUpdated(selected());
+			})
+			.on("brushend", function() {
+				events.brushend.call(pc, __.brushed);
+			});
 
-    brushes[axis] = brush;
-    return brush;
-  };
+		brushes[axis] = brush;
+		return brush;
+	};
 
-  function resetBrushes(dimension) {
-    if (dimension===undefined) {
-      __.brushed = false;
-      if (g) {
-        g.selectAll('.brush')
-          .each(function(d) {
-            d3.select(this)
-              .transition()
-              .duration(0)
-              .call(brushes[d].clear());
-          });
-        pc.renderBrushed();
-      }
-    }
-    else {
-      if (g) {
-        g.selectAll('.brush')
-          .each(function(d) {
-            if (d!=dimension) return;
-            d3.select(this)
-              .transition()
-              .duration(0)
-              .call(brushes[d].clear());
-            brushes[d].event(d3.select(this));
-          });
-        pc.renderBrushed();
-      }
-    }
-    return this;
-  };
+	function brushReset(dimension) {
+		if (dimension===undefined) {
+			__.brushed = false;
+			if (g) {
+				g.selectAll('.brush')
+					.each(function(d) {
+						d3.select(this)
+							.transition()
+							.duration(0)
+							.call(brushes[d].clear());
+					});
+				pc.renderBrushed();
+			}
+		}
+		else {
+			if (g) {
+				g.selectAll('.brush')
+					.each(function(d) {
+						if (d!=dimension) return;
+						d3.select(this)
+							.transition()
+							.duration(0)
+							.call(brushes[d].clear());
+						brushes[d].event(d3.select(this));
+					});
+				pc.renderBrushed();
+			}
+		}
+		return this;
+	};
 
-  function install() {
-    if (!g) pc.createAxes();
+	function install() {
+		if (!g) pc.createAxes();
 
-    // Add and store a brush for each axis.
-    g.append("svg:g")
-      .attr("class", "brush")
-      .each(function(d) {
-        d3.select(this).call(brushFor(d));
-      })
-      .selectAll("rect")
-        .style("visibility", null)
-        .attr("x", -15)
-        .attr("width", 30);
+		// Add and store a brush for each axis.
+		g.append("svg:g")
+			.attr("class", "brush")
+			.each(function(d) {
+				d3.select(this).call(brushFor(d));
+			})
+			.selectAll("rect")
+				.style("visibility", null)
+				.attr("x", -15)
+				.attr("width", 30);
 
-    pc.brushExtents = brushExtents;
-    pc.updateBrush = updateBrush;
-    pc.resetBrushes = resetBrushes;
-    return pc;
-  };
+		pc.brushExtents = brushExtents;
+		pc.updateBrush = updateBrush;
+		pc.brushReset = brushReset;
+		return pc;
+	};
 
-  brush.modes["1D-axes"] = {
-    install: install,
-    uninstall: function() {
-      g.selectAll(".brush").remove();
-      brushes = {};
-      delete pc.brushExtents;
-	    delete pc.updateBrush;
-      delete pc.resetBrushes;
-    },
-    selected: selected,
-    //brushState: brushExtents
-  }
+	brush.modes["1D-axes"] = {
+		install: install,
+		uninstall: function() {
+			g.selectAll(".brush").remove();
+			brushes = {};
+			delete pc.brushExtents;
+			delete pc.updateBrush;
+			delete pc.brushReset;
+		},
+		selected: selected,
+		//brushState: brushExtents
+	}
 })();
 // brush mode: 2D-strums
 // bl.ocks.org/syntagmatic/5441022

--- a/examples/setterForBrushes.html
+++ b/examples/setterForBrushes.html
@@ -9,7 +9,7 @@
 <p>Demonstrates a parallel coordinates plot a pre-set 1D-axes brush.</p>
 </body>
 <script>
-var parcoords = d3.parcoords({nullValueSeparator: "bottom"})("#example")
+var pc = d3.parcoords({nullValueSeparator: "bottom"})("#example")
   .data([
     [0,-0,0,0,0,1],
     [1,-1,1,2,1,1],
@@ -20,7 +20,17 @@ var parcoords = d3.parcoords({nullValueSeparator: "bottom"})("#example")
   .render()
   .shadows()
   .createAxes()
+  .reorderable()
   .brushMode("1D-axes")
-  .setBrushExtents([,,[3,12],,,]);
-  
+  .brushExtents({"2": [3,4]});
+  //.brushExtents([,,[3,4],,,]);
+
+pc.updateBrush(2, [3,12], 500);
+//pc.resetBrushes();
+pc.updateBrush(3, [3,6], 500);
+//pc.resetBrushes();
+
+//parcoords.setBrushExtents([,,[null, null],[3,4],,]);
+//parcoords.brushExtents([,,[3,12],,,]);
+
 </script>

--- a/examples/setterForBrushes.html
+++ b/examples/setterForBrushes.html
@@ -26,11 +26,11 @@ var pc = d3.parcoords({nullValueSeparator: "bottom"})("#example")
   //.brushExtents([,,[3,4],,,]);
 
 pc.updateBrush(2, [3,12], 500);
-//pc.resetBrushes();
+//pc.brushReset();
 pc.updateBrush(3, [3,6], 500);
-//pc.resetBrushes();
+//pc.brushReset();
 
-//parcoords.setBrushExtents([,,[null, null],[3,4],,]);
-//parcoords.brushExtents([,,[3,12],,,]);
+
+//pc.brushExtents([,,[3,12],,,]);
 
 </script>

--- a/src/brushes/1D.js
+++ b/src/brushes/1D.js
@@ -1,246 +1,247 @@
 // brush mode: 1D-Axes
 
 (function() {
-  var brushes = {};
+	var brushes = {};
 
-  function is_brushed(p) {
-    return !brushes[p].empty();
-  }
+	function is_brushed(p) {
+		return !brushes[p].empty();
+	}
 
-  // data within extents
-  function selected() {
-    var actives = __.dimensions.filter(is_brushed),
-        extents = actives.map(function(p) { return brushes[p].extent(); });
+	// data within extents
+	function selected() {
+		var actives = __.dimensions.filter(is_brushed),
+				extents = actives.map(function(p) { return brushes[p].extent(); });
 
-    // We don't want to return the full data set when there are no axes brushed.
-    // Actually, when there are no axes brushed, by definition, no items are
-    // selected. So, let's avoid the filtering and just return false.
-    //if (actives.length === 0) return false;
+		// We don't want to return the full data set when there are no axes brushed.
+		// Actually, when there are no axes brushed, by definition, no items are
+		// selected. So, let's avoid the filtering and just return false.
+		//if (actives.length === 0) return false;
 
-    // Resolves broken examples for now. They expect to get the full dataset back from empty brushes
-    if (actives.length === 0) return __.data;
+		// Resolves broken examples for now. They expect to get the full dataset back from empty brushes
+		if (actives.length === 0) return __.data;
 
-    // test if within range
-    var within = {
-      "date": function(d,p,dimension) {
+		// test if within range
+		var within = {
+			"date": function(d,p,dimension) {
 	if (typeof yscale[p].rangePoints === "function") { // if it is ordinal
-          return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
-        } else {
-          return extents[dimension][0] <= d[p] && d[p] <= extents[dimension][1]
-        }
-      },
-      "number": function(d,p,dimension) {
-        if (typeof yscale[p].rangePoints === "function") { // if it is ordinal
-          return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
-        } else {
-          return extents[dimension][0] <= d[p] && d[p] <= extents[dimension][1]
-        }
-      },
-      "string": function(d,p,dimension) {
-        return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
-      }
-    };
+					return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
+				} else {
+					return extents[dimension][0] <= d[p] && d[p] <= extents[dimension][1]
+				}
+			},
+			"number": function(d,p,dimension) {
+				if (typeof yscale[p].rangePoints === "function") { // if it is ordinal
+					return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
+				} else {
+					return extents[dimension][0] <= d[p] && d[p] <= extents[dimension][1]
+				}
+			},
+			"string": function(d,p,dimension) {
+				return extents[dimension][0] <= yscale[p](d[p]) && yscale[p](d[p]) <= extents[dimension][1]
+			}
+		};
 
-    return __.data
-      .filter(function(d) {
-        switch(brush.predicate) {
-        case "AND":
-          return actives.every(function(p, dimension) {
-            return within[__.types[p]](d,p,dimension);
-          });
-        case "OR":
-          return actives.some(function(p, dimension) {
-            return within[__.types[p]](d,p,dimension);
-          });
-        default:
-          throw "Unknown brush predicate " + __.brushPredicate;
-        }
-      });
-  };
+		return __.data
+			.filter(function(d) {
+				switch(brush.predicate) {
+				case "AND":
+					return actives.every(function(p, dimension) {
+						return within[__.types[p]](d,p,dimension);
+					});
+				case "OR":
+					return actives.some(function(p, dimension) {
+						return within[__.types[p]](d,p,dimension);
+					});
+				default:
+					throw "Unknown brush predicate " + __.brushPredicate;
+				}
+			});
+	};
 
-  function brushExtents(extents) {
-    if(typeof(extents) === 'undefined')
-    {
-      var extents = {};
-      __.dimensions.forEach(function(d) {
-        var brush = brushes[d];
-        if (brush !== undefined && !brush.empty()) {
-          var extent = brush.extent();
-          extent.sort(d3.ascending);
-          extents[d] = extent;
-        }
-      });
-    }
-    else
-    {
-      //first get all the brush selections
-      var brushSelections = {};
-      g.selectAll('.brush')
-        .each(function(d) {
-          brushSelections[d] = d3.select(this);
+	function brushExtents(extents) {
+		if(typeof(extents) === 'undefined')
+		{
+			var extents = {};
+			__.dimensions.forEach(function(d) {
+				var brush = brushes[d];
+				if (brush !== undefined && !brush.empty()) {
+					var extent = brush.extent();
+					extent.sort(d3.ascending);
+					extents[d] = extent;
+				}
+			});
+			return extents;
+		}
+		else
+		{
+			//first get all the brush selections
+			var brushSelections = {};
+			g.selectAll('.brush')
+				.each(function(d) {
+					brushSelections[d] = d3.select(this);
 
-      });
+			});
 
-      // loop over each dimension and update appropriately (if it was passed in through extents)
-      __.dimensions.forEach(function(d) {
-        if (extents[d] === undefined){
-          return pc;
-        }
+			// loop over each dimension and update appropriately (if it was passed in through extents)
+			__.dimensions.forEach(function(d) {
+				if (extents[d] === undefined){
+					continue;
+				}
 
-        var brush = brushes[d];
-        if (brush !== undefined) {
-          //update the extent
-          brush.extent(extents[d]);
+				var brush = brushes[d];
+				if (brush !== undefined) {
+					//update the extent
+					brush.extent(extents[d]);
 
-          //redraw the brush
-          brush(brushSelections[d]);
+					//redraw the brush
+					brush(brushSelections[d]);
 
-          //fire some events
-          brush.event(brushSelections[d]);
-        }
-      });
+					//fire some events
+					brush.event(brushSelections[d]);
+				}
+			});
 
-      //redraw the chart
-      pc.renderBrushed();
-    }
-    return pc;
-  }
+			//redraw the chart
+			pc.renderBrushed();
+		}
+		return pc;
+	}
 
-  /** A setter for 1D-axes brushes, accessible from outside of parcoords. */
-  function updateBrush(dimension, extent, duration) {
-    var brush = brushes[dimension];
-    // set brush extent
-    brush.extent(extent);
-    /*
-    // set brush extents for all dimensions
-    for (var key in initialExtents) {
-      brushes[key].extent(initialExtents[key])
-    }*/
-    if (g) {
-      //first get all the brush selections
-      var brushSelections = {};
-      g.selectAll('.brush')
-        .each(function(d) {
-          brushSelections[d] = d3.select(this);
-        });
+	/** A setter for 1D-axes brushes, accessible from outside of parcoords. */
+	function updateBrush(dimension, extent, duration) {
+		var brush = brushes[dimension];
+		// set brush extent
+		brush.extent(extent);
+		/*
+		// set brush extents for all dimensions
+		for (var key in initialExtents) {
+			brushes[key].extent(initialExtents[key])
+		}*/
+		if (g) {
+			//first get all the brush selections
+			var brushSelections = {};
+			g.selectAll('.brush')
+				.each(function(d) {
+					brushSelections[d] = d3.select(this);
+				});
 
-      //redraw the brush
-      brushSelections[dimension]
-        .transition()
-        .duration(duration)
-        .call(brush)
-      //brush(brushSelections[d]);
+			//redraw the brush
+			brushSelections[dimension]
+				.transition()
+				.duration(duration)
+				.call(brush)
+			//brush(brushSelections[d]);
 
-      //fire some events
-      brush.event(brushSelections[dimension]);
+			//fire some events
+			brush.event(brushSelections[dimension]);
 
-    }
+		}
 
 /*
-    // update all brush extents
-    if (g) {
-      g.selectAll('.brush').each(function(d) {
-  	    if (!(brushes[d].empty())){
-  		  d3.select(this) // draws the brush initially
-  		    .call(brushes[d]);
+		// update all brush extents
+		if (g) {
+			g.selectAll('.brush').each(function(d) {
+				if (!(brushes[d].empty())){
+				d3.select(this) // draws the brush initially
+					.call(brushes[d]);
 
-  		  d3.select(this) // re-draw brushes with set extent, then start brush event
-  		    .transition()
-  		    .duration(duration)
-  		    .call(brushes[d].extent(initialExtents[d]))
-  		    .call(brushes[d].event);
+				d3.select(this) // re-draw brushes with set extent, then start brush event
+					.transition()
+					.duration(duration)
+					.call(brushes[d].extent(initialExtents[d]))
+					.call(brushes[d].event);
 
-  	    } else {
-  		    d3.select(this).call(brushes[d].clear());
-  	    }
-      });
-    }*/
+				} else {
+					d3.select(this).call(brushes[d].clear());
+				}
+			});
+		}*/
 
-    return pc;
-  };
+		return pc;
+	};
 
-  function brushFor(axis) {
-    var brush = d3.svg.brush();
+	function brushFor(axis) {
+		var brush = d3.svg.brush();
 
-    brush
-      .y(yscale[axis])
-      .on("brushstart", function() {
+		brush
+			.y(yscale[axis])
+			.on("brushstart", function() {
 				if(d3.event.sourceEvent !== null) {
 					d3.event.sourceEvent.stopPropagation();
 				}
 			})
-      .on("brush", function() {
-        brushUpdated(selected());
-      })
-      .on("brushend", function() {
-        events.brushend.call(pc, __.brushed);
-      });
+			.on("brush", function() {
+				brushUpdated(selected());
+			})
+			.on("brushend", function() {
+				events.brushend.call(pc, __.brushed);
+			});
 
-    brushes[axis] = brush;
-    return brush;
-  };
+		brushes[axis] = brush;
+		return brush;
+	};
 
-  function resetBrushes(dimension) {
-    if (dimension===undefined) {
-      __.brushed = false;
-      if (g) {
-        g.selectAll('.brush')
-          .each(function(d) {
-            d3.select(this)
-              .transition()
-              .duration(0)
-              .call(brushes[d].clear());
-          });
-        pc.renderBrushed();
-      }
-    }
-    else {
-      if (g) {
-        g.selectAll('.brush')
-          .each(function(d) {
-            if (d!=dimension) return;
-            d3.select(this)
-              .transition()
-              .duration(0)
-              .call(brushes[d].clear());
-            brushes[d].event(d3.select(this));
-          });
-        pc.renderBrushed();
-      }
-    }
-    return this;
-  };
+	function brushReset(dimension) {
+		if (dimension===undefined) {
+			__.brushed = false;
+			if (g) {
+				g.selectAll('.brush')
+					.each(function(d) {
+						d3.select(this)
+							.transition()
+							.duration(0)
+							.call(brushes[d].clear());
+					});
+				pc.renderBrushed();
+			}
+		}
+		else {
+			if (g) {
+				g.selectAll('.brush')
+					.each(function(d) {
+						if (d!=dimension) return;
+						d3.select(this)
+							.transition()
+							.duration(0)
+							.call(brushes[d].clear());
+						brushes[d].event(d3.select(this));
+					});
+				pc.renderBrushed();
+			}
+		}
+		return this;
+	};
 
-  function install() {
-    if (!g) pc.createAxes();
+	function install() {
+		if (!g) pc.createAxes();
 
-    // Add and store a brush for each axis.
-    g.append("svg:g")
-      .attr("class", "brush")
-      .each(function(d) {
-        d3.select(this).call(brushFor(d));
-      })
-      .selectAll("rect")
-        .style("visibility", null)
-        .attr("x", -15)
-        .attr("width", 30);
+		// Add and store a brush for each axis.
+		g.append("svg:g")
+			.attr("class", "brush")
+			.each(function(d) {
+				d3.select(this).call(brushFor(d));
+			})
+			.selectAll("rect")
+				.style("visibility", null)
+				.attr("x", -15)
+				.attr("width", 30);
 
-    pc.brushExtents = brushExtents;
-    pc.updateBrush = updateBrush;
-    pc.resetBrushes = resetBrushes;
-    return pc;
-  };
+		pc.brushExtents = brushExtents;
+		pc.updateBrush = updateBrush;
+		pc.brushReset = brushReset;
+		return pc;
+	};
 
-  brush.modes["1D-axes"] = {
-    install: install,
-    uninstall: function() {
-      g.selectAll(".brush").remove();
-      brushes = {};
-      delete pc.brushExtents;
-	    delete pc.updateBrush;
-      delete pc.resetBrushes;
-    },
-    selected: selected,
-    //brushState: brushExtents
-  }
+	brush.modes["1D-axes"] = {
+		install: install,
+		uninstall: function() {
+			g.selectAll(".brush").remove();
+			brushes = {};
+			delete pc.brushExtents;
+			delete pc.updateBrush;
+			delete pc.brushReset;
+		},
+		selected: selected,
+		//brushState: brushExtents
+	}
 })();

--- a/src/brushes/1D.js
+++ b/src/brushes/1D.js
@@ -85,7 +85,7 @@
 			// loop over each dimension and update appropriately (if it was passed in through extents)
 			__.dimensions.forEach(function(d) {
 				if (extents[d] === undefined){
-					continue;
+					return; // continue
 				}
 
 				var brush = brushes[d];

--- a/src/brushes/1D.js
+++ b/src/brushes/1D.js
@@ -242,6 +242,6 @@
 			delete pc.brushReset;
 		},
 		selected: selected,
-		//brushState: brushExtents
+		brushState: brushExtents
 	}
 })();

--- a/src/events.js
+++ b/src/events.js
@@ -89,7 +89,7 @@ function getset(obj,state,events)  {
 };
 
 function extend(target, source) {
-  for (key in source) {
+  for (var key in source) {
     target[key] = source[key];
   }
   return target;

--- a/src/render.js
+++ b/src/render.js
@@ -20,12 +20,7 @@ pc.renderBrushed = function() {
 };
 
 function isBrushed() {
-  if (__.brushed) {
-    return true;
-  }
-  return false;
-  // TODO: debug: whats going on here??
-  /*if (__.brushed && __.brushed.length !== __.data.length)
+  if (__.brushed && __.brushed.length !== __.data.length)
     return true;
 
   var object = brush.currentMode().brushState();
@@ -35,7 +30,7 @@ function isBrushed() {
       return true;
     }
   }
-  return false;*/
+  return false;
 };
 
 pc.render.default = function() {

--- a/src/render.js
+++ b/src/render.js
@@ -20,7 +20,12 @@ pc.renderBrushed = function() {
 };
 
 function isBrushed() {
-  if (__.brushed && __.brushed.length !== __.data.length)
+  if (__.brushed) {
+    return true;
+  }
+  return false;
+  // TODO: debug: whats going on here??
+  /*if (__.brushed && __.brushed.length !== __.data.length)
     return true;
 
   var object = brush.currentMode().brushState();
@@ -30,7 +35,7 @@ function isBrushed() {
       return true;
     }
   }
-  return false;
+  return false;*/
 };
 
 pc.render.default = function() {


### PR DESCRIPTION
Like other functions brushExtends() returns the brush extents, while brushExtents({'dimension': [from, to]}) sets the new extent and returns 'pc' for chaining.