### PR TITLE
Updated bower and npm files.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,16 +2,9 @@
   "name": "d3.parcoords.js",
   "main": "d3.parcoords.js",
   "dependencies": {
-    "d3": "~3.4",
+    "d3": "~3.5",
     "d3.svg.multibrush": "~0.9.1",
     "sylvester": "~0.1.3"
-  },
-  "devDependencies": {
-    "vows": "~0.7",
-    "d3": "~3.4",
-    "jsdom": "~1.0",
-    "canvas": "~1.1",
-    "smash": "~0.0"
   },
   "ignore": [
     ".git",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     "type": "git",
     "url": "https://github.com/syntagmatic/parallel-coordinates.git"
   },
+  "dependencies": {
+      "d3": "~3.5"
+  },
   "devDependencies": {
     "http-server": "^0.6.1",
-    "d3": "~3.5",
     "vows": "~0.7",
     "jsdom": "~1.0",
     "canvas": "~1.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "http-server": "^0.6.1",
+    "d3": "~3.5",
     "vows": "~0.7",
     "jsdom": "~1.0",
     "canvas": "~1.1",

--- a/package.json
+++ b/package.json
@@ -17,19 +17,18 @@
     "type": "git",
     "url": "https://github.com/syntagmatic/parallel-coordinates.git"
   },
-  "dependencies": {
-    "d3": "~3.4",
-    "d3.svg.multibrush": "~0.9.1",
-    "sylvester": "~0.1.3"
-  },
   "devDependencies": {
+    "http-server": "^0.6.1",
     "vows": "~0.7",
-    "d3": "~3.4",
     "jsdom": "~1.0",
     "canvas": "~1.1",
     "smash": "~0.0"
   },
   "scripts": {
+    "prestart": "npm install",
+    "start": "http-server -a localhost -p 8000 -c-1",
+
+    "pretest": "npm install",
     "test": "vows; echo"
   },
   "licenses": [


### PR DESCRIPTION
This is in reference to pull request #285. I'll recap the changes here. 

In `bower.json`, `d3` was bumped to 3.5 since that's a requirement of `d3.svg.multibrush` (another of this library's dependencies). Additionally, all of the `devDependencies` were removed since they're not being used in the examples. 

For `package.json`, the front end packages were removed because they're not being used and some of them don't exist (making `npm install` fail). Additionally, some commands were added.