### PR TITLE
Added functionality that allows you to programmatically create a screenshot

### DIFF
--- a/d3.parcoords.css
+++ b/d3.parcoords.css
@@ -1,35 +1,19 @@
-.parcoords > svg, .parcoords > canvas { 
+.parcoords > canvas {
   font: 14px sans-serif;
   position: absolute;
 }
 .parcoords > canvas {
   pointer-events: none;
 }
-
 .parcoords text.label {
   cursor: default;
-}
-
-.parcoords rect.background {
-  fill: transparent;
 }
 .parcoords rect.background:hover {
   fill: rgba(120,120,120,0.2);
 }
-.parcoords .resize rect {
-  fill: rgba(0,0,0,0.1);
-}
-.parcoords rect.extent {
-  fill: rgba(255,255,255,0.25);
-  stroke: rgba(0,0,0,0.6);
-}
-.parcoords .axis line, .parcoords .axis path {
-  fill: none;
-  stroke: #222;
-  shape-rendering: crispEdges;
-}
 .parcoords canvas {
   opacity: 1;
+  transition: opacity 0.3s;
   -moz-transition: opacity 0.3s;
   -webkit-transition: opacity 0.3s;
   -o-transition: opacity 0.3s;
@@ -38,11 +22,11 @@
   opacity: 0.25;
 }
 .parcoords {
-	-webkit-touch-callout: none;
-	-webkit-user-select: none;
-	-khtml-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-    background-color: white;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: white;
 }

--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -731,7 +731,18 @@ pc.createAxes = function() {
   g.append("svg:g")
       .attr("class", "axis")
       .attr("transform", "translate(0,0)")
-      .each(function(d) { d3.select(this).call( pc.applyAxisConfig(axis, __.dimensions[d]) )
+      .each(function(d) {
+        var axisElement = d3.select(this).call( pc.applyAxisConfig(axis, __.dimensions[d]) );
+
+        axisElement.selectAll("path")
+            .style("fill", "none")
+            .style("stroke", "#222")
+            .style("shape-rendering", "crispEdges");
+
+        axisElement.selectAll("line")
+            .style("fill", "none")
+            .style("stroke", "#222")
+            .style("shape-rendering", "crispEdges");
       })
     .append("svg:text")
       .attr({
@@ -792,7 +803,18 @@ pc.updateAxes = function(animationTime) {
     .append("svg:g")
       .attr("class", "axis")
       .attr("transform", "translate(0,0)")
-      .each(function(d) { d3.select(this).call( pc.applyAxisConfig(axis, __.dimensions[d]) )
+      .each(function(d) {
+        var axisElement = d3.select(this).call( pc.applyAxisConfig(axis, __.dimensions[d]) );
+
+        axisElement.selectAll("path")
+            .style("fill", "none")
+            .style("stroke", "#222")
+            .style("shape-rendering", "crispEdges");
+
+        axisElement.selectAll("line")
+            .style("fill", "none")
+            .style("stroke", "#222")
+            .style("shape-rendering", "crispEdges");
       })
     .append("svg:text")
       .attr({
@@ -1233,15 +1255,26 @@ pc.brushMode = function(mode) {
 		if (!g) pc.createAxes();
 
 		// Add and store a brush for each axis.
-		g.append("svg:g")
+		var brush = g.append("svg:g")
 			.attr("class", "brush")
 			.each(function(d) {
 				d3.select(this).call(brushFor(d));
-			})
-			.selectAll("rect")
+			});
+
+		brush.selectAll("rect")
 				.style("visibility", null)
 				.attr("x", -15)
 				.attr("width", 30);
+
+		brush.selectAll("rect.background")
+				.style("fill", "transparent");
+
+		brush.selectAll("rect.extent")
+				.style("fill", "rgba(255,255,255,0.25)")
+				.style("stroke", "rgba(0,0,0,0.6)");
+
+		brush.selectAll(".resize rect")
+				.style("fill", "rgba(0,0,0,0.1)");
 
 		pc.brushExtents = brushExtents;
 		pc.brushReset = brushReset;
@@ -1773,15 +1806,26 @@ pc.brushMode = function(mode) {
     if (!g) pc.createAxes();
 
     // Add and store a brush for each axis.
-    g.append("svg:g")
+    var brush = g.append("svg:g")
       .attr("class", "brush")
       .each(function(d) {
         d3.select(this).call(brushFor(d));
       })
-      .selectAll("rect")
+
+    brush.selectAll("rect")
         .style("visibility", null)
         .attr("x", -15)
         .attr("width", 30);
+
+    brush.selectAll("rect.background")
+        .style("fill", "transparent");
+
+    brush.selectAll("rect.extent")
+        .style("fill", "rgba(255,255,255,0.25)")
+        .style("stroke", "rgba(0,0,0,0.6)");
+
+    brush.selectAll(".resize rect")
+        .style("fill", "rgba(0,0,0,0.1)");
 
     pc.brushExtents = brushExtents;
     pc.brushReset = brushReset;

--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -2389,6 +2389,42 @@ function position(d) {
   var v = dragging[d];
   return v == null ? xscale(d) : v;
 }
+
+// Merges the canvases and SVG elements into one canvas element which is then passed into the callback
+// (so you can choose to save it to disk, etc.)
+pc.mergeParcoords = function(callback) {
+
+  // Create a canvas element to store the merged canvases
+  var mergedCanvas = document.createElement("canvas");
+  mergedCanvas.width = pc.canvas.foreground.clientWidth;
+  mergedCanvas.height = pc.canvas.foreground.clientHeight + 30;
+
+  // Give the canvas a white background
+  var context = mergedCanvas.getContext("2d");
+  context.fillStyle = "#ffffff";
+  context.fillRect(0, 0, mergedCanvas.width, mergedCanvas.height);
+
+  // Merge all the canvases
+  for (var key in pc.canvas) {
+    context.drawImage(pc.canvas[key], 0, 24);
+  }
+
+  // Add SVG elements to canvas
+  var DOMURL = window.URL || window.webkitURL || window;
+  var serializer = new XMLSerializer();
+  var svgStr = serializer.serializeToString(pc.selection.select("svg")[0][0]);
+
+  // Create a Data URI.
+  var src = 'data:image/svg+xml;base64,' + window.btoa(svgStr);
+  var img = new Image();
+  img.onload = function () {
+    context.drawImage(img, 0, 0);
+    if (typeof callback === "function") {
+      callback(mergedCanvas);
+    }
+  };
+  img.src = src;
+}
 pc.version = "0.7.0";
   // this descriptive text should live with other introspective methods
   pc.toString = function() { return "Parallel Coordinates: " + d3.keys(__.dimensions).length + " dimensions (" + d3.keys(__.data[0]).length + " total) , " + __.data.length + " rows"; };

--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -2393,6 +2393,8 @@ function position(d) {
 // Merges the canvases and SVG elements into one canvas element which is then passed into the callback
 // (so you can choose to save it to disk, etc.)
 pc.mergeParcoords = function(callback) {
+  // Retina display, etc.
+  var devicePixelRatio = window.devicePixelRatio || 1;
 
   // Create a canvas element to store the merged canvases
   var mergedCanvas = document.createElement("canvas");
@@ -2406,7 +2408,7 @@ pc.mergeParcoords = function(callback) {
 
   // Merge all the canvases
   for (var key in pc.canvas) {
-    context.drawImage(pc.canvas[key], 0, 24);
+    context.drawImage(pc.canvas[key], 0, 24, mergedCanvas.width, mergedCanvas.height - 30);
   }
 
   // Add SVG elements to canvas

--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -2398,8 +2398,10 @@ pc.mergeParcoords = function(callback) {
 
   // Create a canvas element to store the merged canvases
   var mergedCanvas = document.createElement("canvas");
-  mergedCanvas.width = pc.canvas.foreground.clientWidth;
-  mergedCanvas.height = pc.canvas.foreground.clientHeight + 30;
+  mergedCanvas.width = pc.canvas.foreground.clientWidth * devicePixelRatio
+  mergedCanvas.height = (pc.canvas.foreground.clientHeight + 30) * devicePixelRatio;
+  mergedCanvas.style.width = mergedCanvas.width / devicePixelRatio + "px";
+  mergedCanvas.style.height = mergedCanvas.height / devicePixelRatio + "px";
 
   // Give the canvas a white background
   var context = mergedCanvas.getContext("2d");
@@ -2408,7 +2410,7 @@ pc.mergeParcoords = function(callback) {
 
   // Merge all the canvases
   for (var key in pc.canvas) {
-    context.drawImage(pc.canvas[key], 0, 24, mergedCanvas.width, mergedCanvas.height - 30);
+    context.drawImage(pc.canvas[key], 0, 24 * devicePixelRatio, mergedCanvas.width, mergedCanvas.height - 30 * devicePixelRatio);
   }
 
   // Add SVG elements to canvas
@@ -2420,7 +2422,7 @@ pc.mergeParcoords = function(callback) {
   var src = 'data:image/svg+xml;base64,' + window.btoa(svgStr);
   var img = new Image();
   img.onload = function () {
-    context.drawImage(img, 0, 0);
+    context.drawImage(img, 0, 0, img.width * devicePixelRatio, img.height * devicePixelRatio);
     if (typeof callback === "function") {
       callback(mergedCanvas);
     }

--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -59,6 +59,9 @@ var pc = function(selection) {
     .append("svg")
       .attr("width", __.width)
       .attr("height", __.height)
+      .style("font", "14px sans-serif")
+      .style("position", "absolute")
+
     .append("svg:g")
       .attr("transform", "translate(" + __.margin.left + "," + __.margin.top + ")");
 

--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -1708,7 +1708,6 @@ pc.brushMode = function(mode) {
       g.selectAll('.brush')
           .each(function (d) {
             brushSelections[d] = d3.select(this);
-
           });
 
       // loop over each dimension and update appropriately (if it was passed in through extents)
@@ -1778,13 +1777,17 @@ pc.brushMode = function(mode) {
     	  selection
     	  .style("visibility", null)
           .attr("x", -15)
-          .attr("width", 30);
+          .attr("width", 30)
+          .style("fill", "rgba(255,255,255,0.25)")
+          .style("stroke", "rgba(0,0,0,0.6)");
       })
       .resizeAdaption(function(selection) {
     	 selection
     	   .selectAll("rect")
     	   .attr("x", -15)
-    	   .attr("width", 30);
+    	   .attr("width", 30)
+         .style("visibility", null)
+         .style("fill", "rgba(0,0,0,0.1)");
       });
 
     brushes[axis] = brush;

--- a/examples/download.html
+++ b/examples/download.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
+</head>
+<title>Download Parallel Coordinates Example</title>
+<link rel="stylesheet" type="text/css" href="../d3.parcoords.css">
+<link rel="stylesheet" type="text/css" href="style.css">
+<script src="lib/d3.js"></script>
+<script src="../d3.parcoords.js"></script>
+<body>
+<div id="example" class="parcoords" style="width:500px;height:150px"></div>
+<p>Demonstrates the ability to download an image of the parallel coordinate.</p>
+<button onclick="downloadScreenshot()">Download screenshot</button>
+</body>
+<script>
+    var parcoords = d3.parcoords()("#example")
+    .data([
+        [0,-0,0,0,0,1],
+        [1,-1,1,2,1,1],
+        [2,-2,4,4,0.5,1],
+        [3,-3,9,6,0.33,1],
+        [4,-4,16,8,0.25,1]
+    ])
+    .render()
+    .createAxes();
+
+    function downloadScreenshot() {
+
+        var callback = function (canvas) {
+            // Download the image
+            var download = document.createElement("a");
+            download.href = canvas.toDataURL("image/png");
+            download.download = "parallel-coordinate.png";
+            download.click();
+        };
+        parcoords.mergeParcoords(callback);
+    }
+
+</script>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
   <li><a href="examples/upload.html">CSV Upload</a></li>
   <li><a href="examples/reddit.html">Reddit Top 100</a></li>
   <li><a href="examples/superformula.html">Superformula</a></li>
+  <li><a href="examples/download.html">Download screenshot of parallel coordinate</a></li>
 </ul>
 
 <h3>Brushing</h3>
@@ -85,8 +86,8 @@ d3.csv('examples/data/cars.csv', function(data) {
       var center = width*1.5*(1+Math.sin(speed*t/1200)) + domain[0];
 
       pc1.yscale[dimension].brush.extent([
-        d3.max([center-width*0.01, domain[0]-width/400]),  
-        d3.min([center+width*1.01, domain[1]+width/100])  
+        d3.max([center-width*0.01, domain[0]-width/400]),
+        d3.min([center+width*1.01, domain[1]+width/100])
       ])(pc1.g()
           .filter(function(d) {
             return d == dimension;
@@ -226,7 +227,7 @@ var data3 = d3.range(-2*Math.PI,2*Math.PI,Math.PI/40)
 <div id="example-coloring-19" class="parcoords parcoords-coloring float" style="width:180px;height:76px"></div>
 <div style="clear:both"></div>
 <pre><a href="#" class="show-code" data-code="coloring-basic">Show code</a></pre>
-<script id="coloring-basic">var colors = d3.scale.category20b(); 
+<script id="coloring-basic">var colors = d3.scale.category20b();
 
 // create a chart in every element with class "parcoords-coloring"
 d3.selectAll(".parcoords-coloring")
@@ -311,8 +312,8 @@ d3.csv('examples/data/cars.csv', function(data) {
     .style("font-size", "14px");
 });
 
-// update color 
-function change_color(dimension) { 
+// update color
+function change_color(dimension) {
   pcz.svg.selectAll(".dimension")
     .style("font-weight", "normal")
     .filter(function(d) { return d == dimension; })
@@ -477,28 +478,28 @@ pc0 = d3.parcoords()("#example0")
 		d3.select("#smooth").text(this.value);
 		pc0.smoothness(this.value).render();
 	});
-	
+
 	// bundling strength slider
 	d3.select("#bundling").on("change", function() {
 		d3.select("#strength").text(this.value);
 		pc0.bundlingStrength(this.value).render();
 	});
-	
+
 	var select = d3.select("#bundleDimension").append("select").on("change", changeBundle);
-	
+
 	var options = select.selectAll('option')
 		.data(d3.keys(pc0.dimensions()));
-	
+
 	options
 		.enter()
 		.append("option")
 		.attr("value", function(d) {return d;})
 		.text(function(d) {return d;});
-	
+
 	function changeBundle() {
 		pc0.bundleDimension(this.value);
 	}
-	
+
 });
 </script>
 

--- a/src/axis.js
+++ b/src/axis.js
@@ -46,7 +46,18 @@ pc.createAxes = function() {
   g.append("svg:g")
       .attr("class", "axis")
       .attr("transform", "translate(0,0)")
-      .each(function(d) { d3.select(this).call( pc.applyAxisConfig(axis, __.dimensions[d]) )
+      .each(function(d) {
+        var axisElement = d3.select(this).call( pc.applyAxisConfig(axis, __.dimensions[d]) );
+
+        axisElement.selectAll("path")
+            .style("fill", "none")
+            .style("stroke", "#222")
+            .style("shape-rendering", "crispEdges");
+
+        axisElement.selectAll("line")
+            .style("fill", "none")
+            .style("stroke", "#222")
+            .style("shape-rendering", "crispEdges");
       })
     .append("svg:text")
       .attr({
@@ -107,7 +118,18 @@ pc.updateAxes = function(animationTime) {
     .append("svg:g")
       .attr("class", "axis")
       .attr("transform", "translate(0,0)")
-      .each(function(d) { d3.select(this).call( pc.applyAxisConfig(axis, __.dimensions[d]) )
+      .each(function(d) {
+        var axisElement = d3.select(this).call( pc.applyAxisConfig(axis, __.dimensions[d]) );
+
+        axisElement.selectAll("path")
+            .style("fill", "none")
+            .style("stroke", "#222")
+            .style("shape-rendering", "crispEdges");
+
+        axisElement.selectAll("line")
+            .style("fill", "none")
+            .style("stroke", "#222")
+            .style("shape-rendering", "crispEdges");
       })
     .append("svg:text")
       .attr({

--- a/src/brushes/1D.js
+++ b/src/brushes/1D.js
@@ -168,15 +168,26 @@
 		if (!g) pc.createAxes();
 
 		// Add and store a brush for each axis.
-		g.append("svg:g")
+		var brush = g.append("svg:g")
 			.attr("class", "brush")
 			.each(function(d) {
 				d3.select(this).call(brushFor(d));
-			})
-			.selectAll("rect")
+			});
+
+		brush.selectAll("rect")
 				.style("visibility", null)
 				.attr("x", -15)
 				.attr("width", 30);
+
+		brush.selectAll("rect.background")
+				.style("fill", "transparent");
+
+		brush.selectAll("rect.extent")
+				.style("fill", "rgba(255,255,255,0.25)")
+				.style("stroke", "rgba(0,0,0,0.6)");
+
+		brush.selectAll(".resize rect")
+				.style("fill", "rgba(0,0,0,0.1)");
 
 		pc.brushExtents = brushExtents;
 		pc.brushReset = brushReset;

--- a/src/brushes/1D.multi.js
+++ b/src/brushes/1D.multi.js
@@ -185,15 +185,26 @@
     if (!g) pc.createAxes();
 
     // Add and store a brush for each axis.
-    g.append("svg:g")
+    var brush = g.append("svg:g")
       .attr("class", "brush")
       .each(function(d) {
         d3.select(this).call(brushFor(d));
       })
-      .selectAll("rect")
+
+    brush.selectAll("rect")
         .style("visibility", null)
         .attr("x", -15)
         .attr("width", 30);
+
+    brush.selectAll("rect.background")
+        .style("fill", "transparent");
+
+    brush.selectAll("rect.extent")
+        .style("fill", "rgba(255,255,255,0.25)")
+        .style("stroke", "rgba(0,0,0,0.6)");
+
+    brush.selectAll(".resize rect")
+        .style("fill", "rgba(0,0,0,0.1)");
 
     pc.brushExtents = brushExtents;
     pc.brushReset = brushReset;

--- a/src/brushes/1D.multi.js
+++ b/src/brushes/1D.multi.js
@@ -84,7 +84,6 @@
       g.selectAll('.brush')
           .each(function (d) {
             brushSelections[d] = d3.select(this);
-
           });
 
       // loop over each dimension and update appropriately (if it was passed in through extents)
@@ -154,13 +153,17 @@
     	  selection
     	  .style("visibility", null)
           .attr("x", -15)
-          .attr("width", 30);
+          .attr("width", 30)
+          .style("fill", "rgba(255,255,255,0.25)")
+          .style("stroke", "rgba(0,0,0,0.6)");
       })
       .resizeAdaption(function(selection) {
     	 selection
     	   .selectAll("rect")
     	   .attr("x", -15)
-    	   .attr("width", 30);
+    	   .attr("width", 30)
+         .style("visibility", null)
+         .style("fill", "rgba(0,0,0,0.1)");
       });
 
     brushes[axis] = brush;

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -75,6 +75,8 @@ function position(d) {
 // Merges the canvases and SVG elements into one canvas element which is then passed into the callback
 // (so you can choose to save it to disk, etc.)
 pc.mergeParcoords = function(callback) {
+  // Retina display, etc.
+  var devicePixelRatio = window.devicePixelRatio || 1;
 
   // Create a canvas element to store the merged canvases
   var mergedCanvas = document.createElement("canvas");
@@ -88,7 +90,7 @@ pc.mergeParcoords = function(callback) {
 
   // Merge all the canvases
   for (var key in pc.canvas) {
-    context.drawImage(pc.canvas[key], 0, 24);
+    context.drawImage(pc.canvas[key], 0, 24, mergedCanvas.width, mergedCanvas.height - 30);
   }
 
   // Add SVG elements to canvas

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -71,3 +71,39 @@ function position(d) {
   var v = dragging[d];
   return v == null ? xscale(d) : v;
 }
+
+// Merges the canvases and SVG elements into one canvas element which is then passed into the callback
+// (so you can choose to save it to disk, etc.)
+pc.mergeParcoords = function(callback) {
+
+  // Create a canvas element to store the merged canvases
+  var mergedCanvas = document.createElement("canvas");
+  mergedCanvas.width = pc.canvas.foreground.clientWidth;
+  mergedCanvas.height = pc.canvas.foreground.clientHeight + 30;
+
+  // Give the canvas a white background
+  var context = mergedCanvas.getContext("2d");
+  context.fillStyle = "#ffffff";
+  context.fillRect(0, 0, mergedCanvas.width, mergedCanvas.height);
+
+  // Merge all the canvases
+  for (var key in pc.canvas) {
+    context.drawImage(pc.canvas[key], 0, 24);
+  }
+
+  // Add SVG elements to canvas
+  var DOMURL = window.URL || window.webkitURL || window;
+  var serializer = new XMLSerializer();
+  var svgStr = serializer.serializeToString(pc.selection.select("svg")[0][0]);
+
+  // Create a Data URI.
+  var src = 'data:image/svg+xml;base64,' + window.btoa(svgStr);
+  var img = new Image();
+  img.onload = function () {
+    context.drawImage(img, 0, 0);
+    if (typeof callback === "function") {
+      callback(mergedCanvas);
+    }
+  };
+  img.src = src;
+}

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -80,8 +80,10 @@ pc.mergeParcoords = function(callback) {
 
   // Create a canvas element to store the merged canvases
   var mergedCanvas = document.createElement("canvas");
-  mergedCanvas.width = pc.canvas.foreground.clientWidth;
-  mergedCanvas.height = pc.canvas.foreground.clientHeight + 30;
+  mergedCanvas.width = pc.canvas.foreground.clientWidth * devicePixelRatio
+  mergedCanvas.height = (pc.canvas.foreground.clientHeight + 30) * devicePixelRatio;
+  mergedCanvas.style.width = mergedCanvas.width / devicePixelRatio + "px";
+  mergedCanvas.style.height = mergedCanvas.height / devicePixelRatio + "px";
 
   // Give the canvas a white background
   var context = mergedCanvas.getContext("2d");
@@ -90,7 +92,7 @@ pc.mergeParcoords = function(callback) {
 
   // Merge all the canvases
   for (var key in pc.canvas) {
-    context.drawImage(pc.canvas[key], 0, 24, mergedCanvas.width, mergedCanvas.height - 30);
+    context.drawImage(pc.canvas[key], 0, 24 * devicePixelRatio, mergedCanvas.width, mergedCanvas.height - 30 * devicePixelRatio);
   }
 
   // Add SVG elements to canvas
@@ -102,7 +104,7 @@ pc.mergeParcoords = function(callback) {
   var src = 'data:image/svg+xml;base64,' + window.btoa(svgStr);
   var img = new Image();
   img.onload = function () {
-    context.drawImage(img, 0, 0);
+    context.drawImage(img, 0, 0, img.width * devicePixelRatio, img.height * devicePixelRatio);
     if (typeof callback === "function") {
       callback(mergedCanvas);
     }

--- a/src/pc.js
+++ b/src/pc.js
@@ -17,6 +17,9 @@ var pc = function(selection) {
     .append("svg")
       .attr("width", __.width)
       .attr("height", __.height)
+      .style("font", "14px sans-serif")
+      .style("position", "absolute")
+
     .append("svg:g")
       .attr("transform", "translate(" + __.margin.left + "," + __.margin.top + ")");
 


### PR DESCRIPTION
For this function, I made a few changes.

1. First, I made sure all of the CSS styling for the SVG elements were applied inline. This was so that the SVG elements could be merged into a canvas retaining their styling. 

2. Then I created a `mergeParcoords` function which merges the canvases and the SVG elements together into one canvas. 

3. The merged `canvas` element can be used by the consumer in whatever way they want. I added a `download` example which shows how it can be used to download a screenshot of the chart.

4. I added an example to showcase the functionality.

Let me know your thoughts. Thanks!

**Notes:**

- I had tried using a style sheet inside of the root SVG tag, however I encountered issues with this when using IE11.
- Also, I couldn't figure out how to get saving working with IE (I get `SecurityError` whenever I try to save the contents of the merged canvas). This is the main reason why I chose to have the function return a canvas instead of just saving the screenshot.
- We could later use this to create high quality screenshots (Issue #310)