### PR TITLE
Add public function to compute centroids on real axis

### DIFF
--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -543,6 +543,22 @@ function compute_centroids(row) {
 	return centroids;
 }
 
+pc.compute_real_centroids = function(row) {
+	var realCentroids = [];
+
+	var p = d3.keys(__.dimensions);
+	var cols = p.length;
+	var a = 0.5;
+
+	for (var i = 0; i < cols; ++i) {
+		var x = position(p[i]);
+		var y = __.dimensions[p[i]].yscale(row[p[i]]);
+		realCentroids.push([x, y]);
+	}
+
+	return realCentroids;
+}
+
 function compute_control_points(centroids) {
 
 	var cols = centroids.length;

--- a/src/bundling.js
+++ b/src/bundling.js
@@ -61,6 +61,22 @@ function compute_centroids(row) {
 	return centroids;
 }
 
+pc.compute_real_centroids = function(row) {
+	var realCentroids = [];
+
+	var p = d3.keys(__.dimensions);
+	var cols = p.length;
+	var a = 0.5;
+
+	for (var i = 0; i < cols; ++i) {
+		var x = position(p[i]);
+		var y = __.dimensions[p[i]].yscale(row[p[i]]);
+		realCentroids.push([x, y]);
+	}
+
+	return realCentroids;
+}
+
 function compute_control_points(centroids) {
 
 	var cols = centroids.length;


### PR DESCRIPTION
This public function can help use this example https://gist.github.com/mostaphaRoudsari/b4e090bb50146d88aec4 with original source d3.parcoords.js

To get centroid points used in highlight when mouse-over and render tooltip:

```
        function getCentroids() {
            const margins = this.chart.margin();
            const brushedData = this.chart.brushed().length ? this.chart.brushed() : this.data;

            return brushedData.map(d => {
                const centroidPoints = this.chart.compute_real_centroids(d);
                return centroidPoints.map(d => [d[0] + margins.left, d[1] + margins.top]);
            });
        }
```
refs #32 