### PR TITLE
Brush extents fire events fix

### DIFF
--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -1213,9 +1213,13 @@ pc.brushMode = function(mode) {
 						.transition()
 						.duration(0)
 						.call(brush);
-
-					//fire some events
-					brush.event(brushSelections[d]);
+				}
+			});
+			
+			//now all brush extents have been updated: fire some events
+			d3.keys(brushes).forEach(function(d) {
+				if (brushes[d] !== undefined || extents[d] === undefined) {
+					brushes[d].event(brushSelections[d]);
 				}
 			});
 
@@ -1751,9 +1755,13 @@ pc.brushMode = function(mode) {
               .transition()
               .duration(0)
               .call(brush);
-
-          //fire some events
-          brush.event(brushSelections[d]);
+        }
+      });
+	  
+	  //now all brush extents have been updated: fire some events
+      d3.keys(brushes).forEach(function(d) {
+        if (brushes[d] !== undefined || extents[d] === undefined) {
+          brushes[d].event(brushSelections[d]);
         }
       });
 

--- a/src/brushes/1D.js
+++ b/src/brushes/1D.js
@@ -98,9 +98,13 @@
 						.transition()
 						.duration(0)
 						.call(brush);
-
-					//fire some events
-					brush.event(brushSelections[d]);
+				}
+			});
+			
+			//now all brush extents have been updated: fire some events
+			d3.keys(brushes).forEach(function(d) {
+				if (brushes[d] !== undefined || extents[d] === undefined) {
+					brushes[d].event(brushSelections[d]);
 				}
 			});
 

--- a/src/brushes/1D.multi.js
+++ b/src/brushes/1D.multi.js
@@ -102,9 +102,13 @@
               .transition()
               .duration(0)
               .call(brush);
-
-          //fire some events
-          brush.event(brushSelections[d]);
+        }
+      });
+	  
+	  //now all brush extents have been updated: fire some events
+      d3.keys(brushes).forEach(function(d) {
+        if (brushes[d] !== undefined || extents[d] === undefined) {
+          brushes[d].event(brushSelections[d]);
         }
       });
 


### PR DESCRIPTION
brushExtents now fires events only after all new extents have been set. This prevents calls to 'brushend' with incomplete brushings.

Example:
brushExtents updates extent on dimension 1, calls 'brushend' with wrong __.brushed b/c dimension 2 does not have a brush extent yet;
then updates extent on dimension 2, calls 'brushend' again, this time with correct __.brushed