### PR TITLE
Fix broken height resize

### DIFF
--- a/d3.parcoords.js
+++ b/d3.parcoords.js
@@ -2365,6 +2365,9 @@ pc.resize = function() {
   if (flags.brushable) pc.brushReset();
 
   // scales
+  d3.keys(__.dimensions).forEach(function(k) {
+    delete __.dimensions[k].yscale;
+  });
   pc.autoscale();
 
   // axes, destroys old brushes.

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -22,6 +22,9 @@ pc.resize = function() {
   if (flags.brushable) pc.brushReset();
 
   // scales
+  d3.keys(__.dimensions).forEach(function(k) {
+    delete __.dimensions[k].yscale;
+  });
   pc.autoscale();
 
   // axes, destroys old brushes.


### PR DESCRIPTION
When changing the height of the chart, the yscales for each dimension must be recalculated based on the new height.